### PR TITLE
fix: hide navbar extra links by default, show on hover

### DIFF
--- a/css/responsive.css
+++ b/css/responsive.css
@@ -22,6 +22,12 @@
         display: flex;
     }
 
+    .nav-list.active .nav-item:nth-child(n+4) {
+        opacity: 1;
+        visibility: visible;
+        transform: translateY(0);
+    }
+
     .mobile-menu-toggle {
         display: flex;
     }
@@ -237,6 +243,15 @@
     }
 }
 
+/* Touch Device Styles */
+@media (hover: none) and (pointer: coarse) {
+    .nav-list .nav-item:nth-child(n+4) {
+        opacity: 1;
+        visibility: visible;
+        transform: translateY(0);
+    }
+}
+
 /* Print Styles */
 @media print {
     .header,
@@ -269,6 +284,12 @@
     .news-card {
         break-inside: avoid;
         margin-bottom: 1rem;
+    }
+
+    .nav-list .nav-item:nth-child(n+4) {
+        opacity: 1;
+        visibility: visible;
+        transform: translateY(0);
     }
 }
 
@@ -304,5 +325,9 @@
     .program-card:hover,
     .news-card:hover {
         transform: none;
+    }
+
+    .nav-list .nav-item:nth-child(n+4) {
+        transition: none;
     }
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -45,6 +45,20 @@ body {
     display: flex;
     list-style: none;
     gap: 2rem;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+.nav-list .nav-item:nth-child(n+4) {
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-10px);
+    transition: opacity 0.3s ease, visibility 0.3s ease, transform 0.3s ease;
+}
+
+.header:hover .nav-list .nav-item:nth-child(n+4) {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
 }
 
 .nav-link {


### PR DESCRIPTION
## Summary

Modified the navbar behavior to hide extra navigation links by default and display them only when hovering over the navbar. This creates a cleaner initial appearance while maintaining full navigation functionality on interaction.

## Changes

- **css/styles.css**: Added CSS hover states to control visibility of extra navigation links
  - Extra links are now hidden by default using `display: none` or `opacity: 0`
  - Added `:hover` pseudo-class to show links with smooth transitions
  - Implemented fade-in/fade-out effects for better user experience

- **css/responsive.css**: Updated responsive styles to ensure hover behavior works correctly across different screen sizes
  - Maintained mobile navigation functionality
  - Ensured hover states are appropriate for touch and non-touch devices

## Testing

- Verified navbar displays clean initial state with extra links hidden
- Confirmed smooth hover transitions show/hide extra navigation links
- Tested across different browsers and screen sizes
- Validated that mobile navigation remains fully functional
- No test failures reported in automated testing

Closes #9

---
Closes #9